### PR TITLE
diagram fix

### DIFF
--- a/src/DacpacTool/Diagram/DatabaseModelToMermaid.cs
+++ b/src/DacpacTool/Diagram/DatabaseModelToMermaid.cs
@@ -9,10 +9,16 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
     public class DatabaseModelToMermaid
     {
         private readonly IReadOnlyList<SimpleTable> tables;
+        private readonly HashSet<string> duplicateTableNames;
 
         public DatabaseModelToMermaid(IReadOnlyList<SimpleTable> tables)
         {
             this.tables = tables;
+            duplicateTableNames = tables
+                .GroupBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
         private static bool IsValidChar(char c) =>
@@ -28,7 +34,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
 
             foreach (var table in tables)
             {
-                var formattedTableName = Sanitize(table.Name);
+                var formattedTableName = GetFormattedTableName(table);
 
                 sb.AppendLine(CultureInfo.InvariantCulture, $"  {formattedTableName} {{");
                 foreach (var column in table.Columns)
@@ -48,7 +54,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
                     }
 
                     var nullable = column.IsNullable ? "(NULL)" : string.Empty;
-                    sb.AppendLine(CultureInfo.InvariantCulture, $"    {formattedColumnName} {column.StoreType?.Replace(", ", "-", StringComparison.OrdinalIgnoreCase)}{nullable} {pkfk}");
+                    sb.AppendLine(CultureInfo.InvariantCulture, $"    {formattedColumnName} {column.StoreType.Replace(", ", "-", StringComparison.OrdinalIgnoreCase)}{nullable} {pkfk}");
                 }
 
                 sb.AppendLine("  }");
@@ -62,7 +68,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
                         relationship = "}o--o";
                     }
 
-                    var formattedPrincipalTableName = Sanitize(foreignKey.PrincipalTable.Name);
+                    var formattedPrincipalTableName = GetFormattedTableName(foreignKey.PrincipalTable);
                     var formattedForeignKeyName = Sanitize(foreignKey.Name ?? string.Empty);
 
                     sb.AppendLine(CultureInfo.InvariantCulture, $"  {formattedTableName} {relationship}| {formattedPrincipalTableName} : {formattedForeignKeyName}");
@@ -93,6 +99,15 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
             }
 
             return new string(buffer[..index]);
+        }
+
+        private string GetFormattedTableName(SimpleTable table)
+        {
+            var name = duplicateTableNames.Contains(table.Name)
+                ? $"{table.Schema}.{table.Name}"
+                : table.Name;
+
+            return Sanitize(name);
         }
     }
 }

--- a/src/DacpacTool/Diagram/Model/SimpleColumn.cs
+++ b/src/DacpacTool/Diagram/Model/SimpleColumn.cs
@@ -6,7 +6,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram.Model
     {
         public string Name { get; set; } = string.Empty;
 
-        public string? StoreType { get; set; }
+        public string StoreType { get; set; } = string.Empty;
 
         public bool IsNullable { get; set; }
     }

--- a/src/DacpacTool/Diagram/Model/SimpleForeignKey.cs
+++ b/src/DacpacTool/Diagram/Model/SimpleForeignKey.cs
@@ -8,7 +8,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram.Model
     {
         public string? Name { get; set; }
 
-        public SimpleTable PrincipalTable { get; set; } = null!;
+        public required SimpleTable PrincipalTable { get; init; }
 
         public IList<SimpleColumn> Columns { get; init; } = [];
 

--- a/test/DacpacTool.Tests/DiagramBuilderTests.cs
+++ b/test/DacpacTool.Tests/DiagramBuilderTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.IO;
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MSBuild.Sdk.SqlProj.DacpacTool.Diagram;
+using MSBuild.Sdk.SqlProj.DacpacTool.Diagram.Model;
 using Shouldly;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
@@ -39,6 +41,35 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             diagramText.ShouldContain("    Column1 nvarchar(100) PK");
             diagramText.ShouldContain("    Computed computed(2*2)");
+        }
+
+        [TestMethod]
+        public void UsesSchemaQualifiedNamesWhenTableNamesCollide()
+        {
+            var salesOrder = new SimpleTable
+            {
+                Schema = "sales",
+                Name = "Order",
+                Columns =
+                [
+                    new SimpleColumn { Name = "Id", StoreType = "int" },
+                ],
+            };
+
+            var hrOrder = new SimpleTable
+            {
+                Schema = "hr",
+                Name = "Order",
+                Columns =
+                [
+                    new SimpleColumn { Name = "Id", StoreType = "int" },
+                ],
+            };
+
+            var diagram = new DatabaseModelToMermaid(new List<SimpleTable> { salesOrder, hrOrder }).CreateMermaid();
+
+            diagram.ShouldContain("  sales.Order {");
+            diagram.ShouldContain("  hr.Order {");
         }
 
         private static (FileInfo fileInfo, TSqlModel model) BuildSimpleModel()


### PR DESCRIPTION
I was reviewing your work for the diagrams and found that I think if there are multiple tables with the same name across separate schemas, it will cause issue in the mermaid diagram cause both tables will show as the same mermaid entity.

A few other fixes too.

Here was Codex's words
1. src/DacpacTool/Diagram/Model/SimpleTable.cs:9 models Name and Schema separately, but the diagram pipeline does not carry a stable fully-qualified identifier through the model. In practice, the model shape makes it easy for consumers to key or render by Name only, which is exactly what happens in src/DacpacTool/Diagram/DatabaseModelToMermaid.cs:31 and src/DacpacTool/Diagram/DatabaseModelToMermaid.cs:65. Two tables with the
  same name in different schemas will collide in Mermaid output. I would treat that as the real design issue in this model area.
2. src/DacpacTool/Diagram/Model/SimpleForeignKey.cs:11 uses PrincipalTable = null!, which means the type advertises a non-null invariant but cannot enforce it. That is workable for an internal DTO, but it is fragile if construction ever expands beyond the current factory. A constructor or required property would make the model safer.
3. src/DacpacTool/Diagram/Model/SimpleColumn.cs:9 leaves StoreType nullable even though the factory currently always assigns a value, including "unknown" in fallback paths at src/DacpacTool/Diagram/DacpacModelFactory.cs:205. That mismatch leaks uncertainty into consumers for no real benefit.